### PR TITLE
Added event parameter to the ipcRenderer mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ipcMain.on('request', function (e, ...args) {
   e.sender.send('response', 'world');
 });
 
-ipcRenderer.on('response', function (...args) {
+ipcRenderer.on('response', function (e, ...args) {
   console.log(args[0]); // 'world'
 });
 

--- a/lib/ipc-renderer.js
+++ b/lib/ipc-renderer.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import Event from './event';
 import { UNIQUE } from './constants';
 
 class IpcRenderer  {
@@ -21,7 +22,8 @@ class IpcRenderer  {
   sendToHost(channel, ...args) {}
 
   _onReceiveFromMain(channel, ...args) {
-    this._emitter.emit(channel, ...args);
+    const e = new Event(this._emitter);
+    this._emitter.emit(channel, e, ...args);
   }
 
   /**

--- a/test/test.communication.js
+++ b/test/test.communication.js
@@ -17,13 +17,15 @@ describe('electron-ipc-mock', function () {
     ipcRenderer.send('test-event', 1, null, 'hello');
 
     ipcMain.on('test-event', function (e, arg1, arg2, arg3) {
+      expect(e).to.be.an.object;
       expect(arg1).to.be.equal(1);
       expect(arg2).to.be.equal(null);
       expect(arg3).to.be.equal('hello');
 
       // Bind listener after sending response to ensure asyncness
       e.sender.send('test-response', 'hello', 'world');
-      ipcRenderer.on('test-response', function (arg1, arg2) {
+      ipcRenderer.on('test-response', function (e, arg1, arg2) {
+        expect(e).to.be.an.object;
         expect(arg1).to.be.equal('hello');
         expect(arg2).to.be.equal('world');
         done();


### PR DESCRIPTION
The mocked ipcRenderer api does not match the original [electron ipc api](http://electron.atom.io/docs/api/ipc-main/).

The mock is missing the `event` parameter from:

``` javascript
ipcRenderer.on('asynchronous-reply', (event, arg) => {
  console.log(arg); // prints "pong"
});
```
